### PR TITLE
Fix for response code logging

### DIFF
--- a/src/main/java/com/comcast/drivethru/api/HTTPRequestManager.java
+++ b/src/main/java/com/comcast/drivethru/api/HTTPRequestManager.java
@@ -19,8 +19,12 @@
 
 package com.comcast.drivethru.api;
 
+import static com.comcast.drivethru.constants.ServerStatusCodes.*;
+
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -47,12 +51,25 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.comcast.drivethru.constants.ServerStatusCodes;
 import com.comcast.drivethru.model.ResponseContainer;
 
 public final class HTTPRequestManager
 {
     // PROPERTIES ----------------------------------------------------------------------------------------------------------
+    
+    List<Integer> SUCCESS_CODES = Arrays.asList(new Integer[]
+    { 
+        OK, 
+        CREATED, 
+        ACCEPTED, 
+        NONAUTHORITATIVE_INFORMATION, 
+        NO_CONTENT,
+        RESET_CONTENT,
+        PARTIAL_CONTENT,
+        MULTI_STATUS,
+        ALREADY_REPORTED,
+        IM_USED 
+    });
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HTTPRequestManager.class);
 
@@ -291,8 +308,8 @@ public final class HTTPRequestManager
             String responseLog = "Response: " + responseCode + " - ";
 
             if (responseText != null) responseLog += responseText;
-
-            if (responseCode >= ServerStatusCodes.OK && responseCode <= ServerStatusCodes.PARTIAL_CONTENT)
+            
+            if (SUCCESS_CODES.contains(responseCode))
             {
                 LOGGER.info(responseLog);
             }

--- a/src/main/java/com/comcast/drivethru/api/HTTPRequestManager.java
+++ b/src/main/java/com/comcast/drivethru/api/HTTPRequestManager.java
@@ -292,7 +292,7 @@ public final class HTTPRequestManager
 
             if (responseText != null) responseLog += responseText;
 
-            if (responseCode == ServerStatusCodes.OK)
+            if (responseCode >= ServerStatusCodes.OK && responseCode <= ServerStatusCodes.PARTIAL_CONTENT)
             {
                 LOGGER.info(responseLog);
             }

--- a/src/main/java/com/comcast/drivethru/constants/ServerStatusCodes.java
+++ b/src/main/java/com/comcast/drivethru/constants/ServerStatusCodes.java
@@ -24,6 +24,7 @@ public class ServerStatusCodes
     // Informational
     public static final int CONTINUE = 100;
     public static final int SWITCHING_PROTOCOLS = 101;
+    public static final int PROCESSING = 102;
 
     // Successful
     public static final int OK = 200;
@@ -33,14 +34,20 @@ public class ServerStatusCodes
     public static final int NO_CONTENT = 204;
     public static final int RESET_CONTENT = 205;
     public static final int PARTIAL_CONTENT = 206;
+    public static final int MULTI_STATUS = 207;
+    public static final int ALREADY_REPORTED = 208;
+    public static final int IM_USED = 226;
 
     // Redirection
+    public static final int MULTIPLE_CHOICES = 300;
     public static final int MOVED_PERMANTENTLY = 301;
     public static final int FOUND = 302;
     public static final int SEE_OTHER = 303;
     public static final int NOT_MODIFIED = 304;
     public static final int USE_PROXY = 305;
+    public static final int SWITCH_PROXY = 306;
     public static final int TEMPORARY_REDIRECT = 307;
+    public static final int PERMANENT_REDIRECT = 308;
 
     // Client Error
     public static final int BAD_REQUEST = 400;
@@ -61,6 +68,16 @@ public class ServerStatusCodes
     public static final int UNSUPPORTED_MEDIA_TYPE = 415;
     public static final int REQUEST_RANGE_NOT_SATISFIABLE = 416;
     public static final int EXPECTATION_FAILED = 417;
+    public static final int IM_A_TEAPOT = 418;
+    public static final int MISDIRECTED_REQUEST = 421;
+    public static final int UNPROCESSABLE_ENTITY = 422;
+    public static final int LOCKED = 423;
+    public static final int FAILED_DEPENDENCY = 424;
+    public static final int UPGRADE_REQUIRED = 426;
+    public static final int PRECONDITION_REQUIRED = 428;
+    public static final int TOO_MANY_REQUESTS = 429;
+    public static final int REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+    public static final int UNAVAILABLE_FOR_LEGAL_REASONS = 451;
 
     // Server Error
     public static final int INTERNAL_SERVER_ERROR = 500;
@@ -69,4 +86,9 @@ public class ServerStatusCodes
     public static final int SERVICE_UNAVAILABLE = 503;
     public static final int GATEWAY_TIMEOUT = 504;
     public static final int HTTP_VERSION_NOT_SUPPORTED = 505;
+    public static final int VARIANT_ALSO_NEGOTIATES = 506;
+    public static final int INSUFFICIENT_STORAGE = 507;
+    public static final int LOOP_DETECTED = 508;
+    public static final int NOT_EXTENDED = 510;
+    public static final int NETWORK_AUTHENTICATION_REQUIRED = 511;
 }


### PR DESCRIPTION
Changed logging so that all 200-range response codes log as info, not as error. (i.e. a response of 202 has been logging as an error)
