### PR TITLE
repairing stack trace chain

### DIFF
--- a/src/main/java/com/comcast/drivethru/api/HTTPRequestManager.java
+++ b/src/main/java/com/comcast/drivethru/api/HTTPRequestManager.java
@@ -348,7 +348,7 @@ public class HTTPRequestManager
         }
         catch (IOException e)
         {
-            throw new IOException("Connection failed. Request not sent");
+            throw new IOException("Connection failed. Request not sent", e);
         }
         finally
         {


### PR DESCRIPTION
HttpRequestManager is generically capturing an IOException and re-throwing an IOException but it does not pass the original along.  This means that an outside project won't have the full stack trace about the more specific cause of the failure.

This change restores that with two characters; three if you count whitespace.  :)